### PR TITLE
Proper C++ standard header name

### DIFF
--- a/src/maths/maths_func.h
+++ b/src/maths/maths_func.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-#include <math.h>
+#include <cmath>
 
 #define PI 3.14159265358f
 


### PR DESCRIPTION
Changing the C <ABC.h> format to the C++ <cABC>